### PR TITLE
sets openoffice to unsupported & refactors in fail

### DIFF
--- a/.github/workflows/plugin_test.yml
+++ b/.github/workflows/plugin_test.yml
@@ -16,28 +16,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: asdf_plugin_test_zeppelin
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "zeppelin"
         env:
           DEBUG: 1
       - name: asdf_plugin_test_kafka
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "kafka"
         env:
           DEBUG: 1
       - name: asdf_plugin_test_flink
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "flink"
         env:
           DEBUG: 1
       - name: asdf_plugin_test_druid
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "druid"
@@ -52,28 +52,28 @@ jobs:
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew install parallel
       - name: asdf_plugin_test_flink
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "flink"
         env:
           DEBUG: 1
       - name: asdf_plugin_test_zeppelin
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "zeppelin"
         env:
           DEBUG: 1
       - name: asdf_plugin_test_druid
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "druid"
         env:
           DEBUG: 1
       - name: asdf_plugin_test_kafka
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2.2.0
         with:
           command: " "
           plugin: "kafka"

--- a/.github/workflows/plugin_test.yml
+++ b/.github/workflows/plugin_test.yml
@@ -15,13 +15,6 @@ jobs:
   ubuntu_test:
     runs-on: ubuntu-latest
     steps:
-      - name: asdf_plugin_test_flink
-        uses: asdf-vm/actions/plugin-test@v1.1.0
-        with:
-          command: " "
-          plugin: "flink"
-        env:
-          DEBUG: 1
       - name: asdf_plugin_test_zeppelin
         uses: asdf-vm/actions/plugin-test@v1.1.0
         with:
@@ -29,18 +22,25 @@ jobs:
           plugin: "zeppelin"
         env:
           DEBUG: 1
-      - name: asdf_plugin_test_druid
-        uses: asdf-vm/actions/plugin-test@v1.1.0
-        with:
-          command: " "
-          plugin: "druid"
-        env:
-          DEBUG: 1
       - name: asdf_plugin_test_kafka
         uses: asdf-vm/actions/plugin-test@v1.1.0
         with:
           command: " "
           plugin: "kafka"
+        env:
+          DEBUG: 1
+      - name: asdf_plugin_test_flink
+        uses: asdf-vm/actions/plugin-test@v1.1.0
+        with:
+          command: " "
+          plugin: "flink"
+        env:
+          DEBUG: 1
+      - name: asdf_plugin_test_druid
+        uses: asdf-vm/actions/plugin-test@v1.1.0
+        with:
+          command: " "
+          plugin: "druid"
         env:
           DEBUG: 1
 

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on
 
 ### Including site-docs versions
 `INCLUDE_SITE_DOCS=true asdf list-all kafka`
+
+### Apache use
+  Zeppelin
+    - make sure you have java installed [asdf-java](https://github.com/halcyon/asdf-java)
+    - install zeppelin: `asdf install zeppelin ${SOME_VERSION}`
+    - then once zeppelin is installed: `asdf global zeppelin ${SOME_VERSION}`
+    - `zeppelin-daemon.sh start`
+    - more information on zeppelin: https://zeppelin.apache.org/docs/latest/quickstart/install.html

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ asdf plugin-add pulsar https://github.com/jtzero/asdf-apache.git
 ```
 asdf plugin-add kafka https://github.com/jtzero/asdf-apache.git
 ```
+=======
+
+### Unsupported
+* openoffice
 
 
 ## Use
@@ -25,7 +29,7 @@ asdf plugin-add kafka https://github.com/jtzero/asdf-apache.git
 Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage asdf plugin versions
 
 ### Including source versions
-`INCLUDE_SRC=1 asdf list-all pulsar`
+`INCLUDE_SRC=true asdf list-all pulsar`
 
 ### Including site-docs versions
-`INCLUDE_SITE_DOCS=1 asdf list-all pulsar`
+`INCLUDE_SITE_DOCS=true asdf list-all kafka`

--- a/bin/install
+++ b/bin/install
@@ -9,3 +9,7 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+
+if [ -n "${DEBUG:-}" ]; then
+  set +x
+fi

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -2,5 +2,9 @@
 
 set -euo pipefail
 
-# shellcheck source=../lib/utils.bash
+export KEEP_DEBUG=true
 "$(dirname "$0")/list-all" | tr -d '\n' | sed 's/\s/\n/g' | tail -n 1
+
+if [ -n "${DEBUG:-}" ]; then
+  set +x
+fi

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 export KEEP_DEBUG=true
-"$(dirname "$0")/list-all" | tr -d '\n' | sed 's/\s/\n/g' | tail -n 1
+"$(dirname "$0")/list-all" | tr -d '\n' | sed 's/[[:space:]]/\n/g' | tail -n 1
 
 if [ -n "${DEBUG:-}" ]; then
   set +x

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 # shellcheck source=../lib/utils.bash
-"$(dirname "$0")/list-all" | grep -o '\s[^\s]*$' | sed 's/ //'
+"$(dirname "$0")/list-all" | grep -o '\s[^\s]*$' | tr -d ' '

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 # shellcheck source=../lib/utils.bash
-"$(dirname "$0")/list-all" | grep -o '\s[^\s]*$' | tr -d ' '
+"$(dirname "$0")/list-all" | tr -d '\n' | sed 's/\s/\n/g' | tail -n 1

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source=../lib/utils.bash
+"$(dirname "$0")/list-all" | grep -o '\s[^\s]*$' | sed 's/ //'

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-DEBUG="${DEBUG:-}"
-
 BIN_DIR=""
 BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BIN_DIR
@@ -106,7 +104,8 @@ get_versions() {
   count="$(wc -l <<<"${init_versions}")"
 
   # shellcheck disable=SC2005 # not sure if the echo is needed TODO
-  printf '%s' "$(parallel --jobs "$count" get_sub_versions "${product_name}" "${include_src}" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " "
+  printf '%s' "$(parallel --jobs "$count" get_sub_versions "${product_name}" "${include_src}" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " " | tr -s ' '
+  printf '\n'
 }
 
 case "${PRODUCT_NAME}" in

--- a/bin/list-all
+++ b/bin/list-all
@@ -111,7 +111,7 @@ get_versions() {
   count="$(wc -l <<<"${init_versions}")"
 
   # shellcheck disable=SC2005 # not sure if the echo is needed TODO
-  printf '%s\n' "$(parallel --jobs "$count" get_sub_versions "${product_name}" "${include_src}" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " "
+  printf '%s' "$(parallel --jobs "$count" get_sub_versions "${product_name}" "${include_src}" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " "
 }
 
 case "${PRODUCT_NAME}" in

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 DEBUG="${DEBUG:-}"
 
 if [ -n "${DEBUG}" ]; then
-  set -x
+  set -xv
 fi
 
 BIN_DIR=""
@@ -19,7 +19,7 @@ readonly THIS_PLUGIN_LIB_DIR="${THIS_PLUGIN_DIR}/lib"
 FOLDER_NAME="$(basename "${THIS_PLUGIN_DIR}")"
 PRODUCT_NAME="${PRODUCT_NAME:-$FOLDER_NAME}"
 readonly PRODUCT_NAME
-TOOL_PRODUCT_NAME="$(basename "$(dirname "${ASDF_INSTALL_PATH}")")"
+TOOL_PRODUCT_NAME="$(basename "${THIS_PLUGIN_DIR}")"
 readonly TOOL_PRODUCT_NAME
 readonly TOOL_NAME="apache"
 
@@ -112,13 +112,15 @@ get_versions() {
   export -f releases_path
   export -f list_versions
   export -f sort_top_level_versions
+  export DEBUG
+  export THIS_PLUGIN_LIB_DIR
 
   release_path="$(releases_path "${product_name}")"
   init_versions="$(list_release_folders "${product_name}" "${release_path}")"
   count="$(wc -l <<<"${init_versions}")"
 
   # shellcheck disable=SC2005 # not sure if the echo is needed TODO
-  echo "$(parallel --jobs "$count" get_sub_versions "${product_name}" "${include_src}" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " "
+  printf '%s\n' "$(parallel --jobs "$count" get_sub_versions "${product_name}" "${include_src}" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " "
 }
 
 case "${PRODUCT_NAME}" in

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,29 +12,40 @@ BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BIN_DIR
 
 declare THIS_PLUGIN_DIR PRODUCT_NAME
-readonly INCLUDE_SRC="${INCLUDE_SRC:-1}"
+readonly INCLUDE_SRC="${INCLUDE_SRC:-false}"
 THIS_PLUGIN_DIR="$(dirname "${BIN_DIR}")"
 readonly THIS_PLUGIN_DIR
 readonly THIS_PLUGIN_LIB_DIR="${THIS_PLUGIN_DIR}/lib"
-PRODUCT_NAME="$(basename "${THIS_PLUGIN_DIR}")"
+FOLDER_NAME="$(basename "${THIS_PLUGIN_DIR}")"
+PRODUCT_NAME="${PRODUCT_NAME:-$FOLDER_NAME}"
 readonly PRODUCT_NAME
+TOOL_PRODUCT_NAME="$(basename "$(dirname "${ASDF_INSTALL_PATH}")")"
+readonly TOOL_PRODUCT_NAME
+readonly TOOL_NAME="apache"
 
-{ command -vp curl >/dev/null; } 2>&1 || (echo >&2 'Missing curl' && exit 1)
-{ command -v parallel >/dev/null; } 2>&1 || (echo >&2 'Missing gnu parallel' && exit 1)
+curl_opts=(-fsSL)
+
+fail() {
+  echo -e "asdf-$TOOL_NAME|$TOOL_PRODUCT_NAME: $*"
+  exit 1
+}
+
+command -vp curl >/dev/null 2>&1 || fail 'Missing curl'
+command -v parallel >/dev/null 2>&1 || fail 'Missing gnu parallel'
 
 releases_path() {
-  local product_name="${1}"
-  local version="${2:-}"
+  local -r product_name="${1}"
+  local -r version="${2:-}"
   echo "https://archive.apache.org/dist/${product_name}/${version}"
 }
 
 list_release_folders() {
-  local product_name="$1"
-  local releases_path="$2"
-  local curl_cmd cmd raw_versions trimmed_versions grep_str
-  curl_cmd="$(command -vp curl)"
-  cmd="${curl_cmd} -fsS"
+  local -r product_name="$1"
+  local -r releases_path="$2"
+  local -r curl_cmd="$(command -vp curl)"
+  local -r cmd="${curl_cmd} ${curl_opts[*]}"
 
+  local raw_versions trimmed_versions grep_str
   raw_versions="$(eval "${cmd}" "${releases_path}")"
   grep_str='href=".+\/">'
   trimmed_versions="$(echo "${raw_versions}" | grep -oE "${grep_str}" | sed -E 's/.+"(apache-)?(.+)">/\2/g' | cut -d/ -f1)"
@@ -42,12 +53,13 @@ list_release_folders() {
 }
 
 list_versions() {
-  local product_name="$1"
-  local releases_path="$2"
-  local curl_cmd cmd raw_versions trimmed_versions grep_str
-  curl_cmd="$(command -vp curl)"
-  cmd="${curl_cmd} -fsS"
+  local -r product_name="$1"
+  local -r releases_path="$2"
 
+  local -r curl_cmd="$(command -vp curl)"
+  local -r cmd="${curl_cmd} ${curl_opts[*]}"
+
+  local raw_versions trimmed_versions grep_str
   raw_versions="$(eval "${cmd}" "${releases_path}")"
   grep_str='href=".*'"(${product_name})?"'.+(tgz|tar.gz)">'
   trimmed_versions="$(echo "${raw_versions}" | grep -oE "${grep_str}" | sed -E 's/.+"(apache-)?(.+)">/\2/g' | cut -d/ -f1)"
@@ -66,9 +78,9 @@ sort_sub_versions() {
 }
 
 get_sub_versions() {
-  local product_name="$1"
-  local include_src="$2"
-  local version="$3"
+  local -r product_name="$1"
+  local -r include_src="$2"
+  local -r version="$3"
   local sub_release_path file_names
   local product_lib_file="${THIS_PLUGIN_LIB_DIR}/${product_name}.sh"
   sub_release_path="$(releases_path "${product_name}" "${version}/")"
@@ -78,7 +90,7 @@ get_sub_versions() {
     . "${product_lib_file}"
     list_sub_versions "${file_names}" "${include_src}"
   else
-    if [ "${include_src}" = "0" ]; then
+    if [ "${include_src}" = "false" ]; then
       printf "%s" "${file_names}" |
         grep -E 'tgz|tar\.gz' |
         sed -E 's/'"${product_name}"'-(.+)(\.tgz|\.tar.gz)/\1/g' |
@@ -92,17 +104,31 @@ get_sub_versions() {
   fi
 }
 
-export -f get_sub_versions
-export -f releases_path
-export -f list_versions
-export -f sort_top_level_versions
-export SHELLOPTS
-export THIS_PLUGIN_LIB_DIR
-release_path="$(releases_path "${PRODUCT_NAME}")"
-init_versions="$(list_release_folders "${PRODUCT_NAME}" "${release_path}")"
-count="$(wc -l <<<"${init_versions}" | tr -d " ")"
-# shellcheck disable=SC2005
-echo "$(parallel --jobs "${count}" get_sub_versions "${PRODUCT_NAME}" "1" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " "
+get_versions() {
+  local -r product_name="${1}"
+  local -r include_src="${2:-false}"
+
+  export -f get_sub_versions
+  export -f releases_path
+  export -f list_versions
+  export -f sort_top_level_versions
+
+  release_path="$(releases_path "${product_name}")"
+  init_versions="$(list_release_folders "${product_name}" "${release_path}")"
+  count="$(wc -l <<<"${init_versions}")"
+
+  # shellcheck disable=SC2005 # not sure if the echo is needed TODO
+  echo "$(parallel --jobs "$count" get_sub_versions "${product_name}" "${include_src}" <<<"${init_versions}")" | sort_sub_versions | tr "\n" " "
+}
+
+case "${PRODUCT_NAME}" in
+openoffice)
+  fail "Not supported ${PRODUCT_NAME}"
+  ;;
+*)
+  get_versions "${PRODUCT_NAME}" "${INCLUDE_SRC}"
+  ;;
+esac
 
 if [ -n "${DEBUG}" ]; then
   set +x

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,10 +3,6 @@ set -Eeuo pipefail
 
 DEBUG="${DEBUG:-}"
 
-if [ -n "${DEBUG}" ]; then
-  set -xv
-fi
-
 BIN_DIR=""
 BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BIN_DIR
@@ -68,7 +64,6 @@ sort_sub_versions() {
 get_sub_versions() {
   # shellcheck source=../lib/utils.bash
   . "${THIS_PLUGIN_LIB_DIR}/utils.bash"
-
   local -r product_name="$1"
   local -r include_src="$2"
   local -r version="$3"
@@ -122,7 +117,3 @@ openoffice)
   get_versions "${PRODUCT_NAME}" "${INCLUDE_SRC}"
   ;;
 esac
-
-if [ -n "${DEBUG}" ]; then
-  set +x
-fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -122,3 +122,7 @@ openoffice)
   get_versions "${PRODUCT_NAME}" "${INCLUDE_SRC}"
   ;;
 esac
+
+if [ -n "${DEBUG:-}" ]; then
+  set +x
+fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -16,22 +16,9 @@ readonly INCLUDE_SRC="${INCLUDE_SRC:-false}"
 THIS_PLUGIN_DIR="$(dirname "${BIN_DIR}")"
 readonly THIS_PLUGIN_DIR
 readonly THIS_PLUGIN_LIB_DIR="${THIS_PLUGIN_DIR}/lib"
-FOLDER_NAME="$(basename "${THIS_PLUGIN_DIR}")"
-PRODUCT_NAME="${PRODUCT_NAME:-$FOLDER_NAME}"
-readonly PRODUCT_NAME
-TOOL_PRODUCT_NAME="$(basename "${THIS_PLUGIN_DIR}")"
-readonly TOOL_PRODUCT_NAME
-readonly TOOL_NAME="apache"
 
-curl_opts=(-fsSL)
-
-fail() {
-  echo -e "asdf-$TOOL_NAME|$TOOL_PRODUCT_NAME: $*"
-  exit 1
-}
-
-command -vp curl >/dev/null 2>&1 || fail 'Missing curl'
-command -v parallel >/dev/null 2>&1 || fail 'Missing gnu parallel'
+# shellcheck source=../lib/utils.bash
+. "${THIS_PLUGIN_LIB_DIR}/utils.bash"
 
 releases_path() {
   local -r product_name="${1}"
@@ -77,7 +64,11 @@ sort_sub_versions() {
   sed -E 's/(.+)/\1|\1/;s/(([0-9]+)\.([0-9]*)(\.?([0-9])*))-?(.)?(.*\|(.+))/\2|\3|\5|\6|\8/g;' | sort -t"|" -k 1,1n -k2,2n -k3,3n -k4,4r | cut -d"|" -f5
 }
 
+# TODO move this to libexec
 get_sub_versions() {
+  # shellcheck source=../lib/utils.bash
+  . "${THIS_PLUGIN_LIB_DIR}/utils.bash"
+
   local -r product_name="$1"
   local -r include_src="$2"
   local -r version="$3"

--- a/bin/list-all
+++ b/bin/list-all
@@ -123,6 +123,6 @@ openoffice)
   ;;
 esac
 
-if [ -n "${DEBUG:-}" ]; then
+if [ "${KEEP_DEBUG:-}" != "true" ] && [ -n "${DEBUG:-}" ]; then
   set +x
 fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -36,14 +36,20 @@ list_release_folders() {
 list_versions() {
   local -r product_name="$1"
   local -r releases_path="$2"
+  local -r include_src="${3:-false}"
 
   local -r curl_cmd="$(command -vp curl)"
   local -r cmd="${curl_cmd} ${curl_opts[*]}"
+  local -r grep_str='href=".*'"(${product_name})?"'.+(tgz|tar.gz)">'
 
-  local raw_versions trimmed_versions grep_str
+  local raw_versions trimmed_versions
   raw_versions="$(eval "${cmd}" "${releases_path}")"
-  grep_str='href=".*'"(${product_name})?"'.+(tgz|tar.gz)">'
-  trimmed_versions="$(echo "${raw_versions}" | grep -oE "${grep_str}" | sed -E 's/.+"(apache-)?(.+)">/\2/g' | cut -d/ -f1)"
+  if [ "${include_src}" = "true" ]; then
+    trimmed_versions="$(echo "${raw_versions}" | grep -oE "${grep_str}" | sed -E 's/.+"(apache-)?(.+)">/\2/g' | cut -d/ -f1)"
+  else
+    trimmed_versions="$(echo "${raw_versions}" | grep -oE "${grep_str}" | grep -v '\-src' | sed -E 's/.+"(apache-)?(.+)">/\2/g' | cut -d/ -f1)"
+  fi
+
   echo "${trimmed_versions}" | sort_top_level_versions
 }
 

--- a/lib/kafka.sh
+++ b/lib/kafka.sh
@@ -24,20 +24,20 @@ list_sub_versions() {
     sed -E 's/'"${product_name}"'[-_](.+)(\.tgz|\.tar.gz)/\1/g')"
 
   local filters=()
-  if [ "${include_src}" = "true" ]; then
+  if [ "${include_src}" = "false" ]; then
     filters[1]='\-src'
   fi
-  if [ "${include_site_docs}" = "true" ]; then
+  if [ "${include_site_docs}" = "false" ]; then
     filters[2]='\-site-docs'
   fi
 
   local filter_clause=""
-  filter_clause="$(join_by '|' "${filters[1]}" "${filters[2]}")"
+  filter_clause="$(join_by '|' "${filters[1]:-}" "${filters[2]:-}")"
 
-  if [ -n "${filter_clause}" ]; then
-    printf "%s" "${compressed}" | grep -E -v "${filter_clause}"
-  else
+  if [ "${filter_clause}" = "|" ]; then
     printf "%s" "${compressed}"
+  else
+    printf "%s" "${compressed}" | grep -E -v "${filter_clause}"
   fi
 }
 

--- a/lib/kafka.sh
+++ b/lib/kafka.sh
@@ -17,18 +17,17 @@ default_filename_extended_pattern() {
 list_sub_versions() {
   local file_names="${1}"
   local include_src="${2}"
-  local include_site_docs="${INCLUDE_SITE_DOCS:-0}"
+  local include_site_docs="${INCLUDE_SITE_DOCS:-false}"
   local compressed
-  include_site_docs="${3:-1}"
   compressed="$(printf "%s" "${file_names}" |
     grep -E 'tgz|tar\.gz' |
     sed -E 's/'"${product_name}"'[-_](.+)(\.tgz|\.tar.gz)/\1/g')"
 
   local filters=()
-  if [ "${include_src}" = "1" ]; then
+  if [ "${include_src}" = "true" ]; then
     filters[1]='\-src'
   fi
-  if [ "${include_site_docs}" = "1" ]; then
+  if [ "${include_site_docs}" = "true" ]; then
     filters[2]='\-site-docs'
   fi
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -12,17 +12,17 @@ readonly LIB_DIR
 if [ -z "${THIS_PLUGIN_DIR:-}" ]; then
   THIS_PLUGIN_DIR="$(dirname "${LIB_DIR}")"
 fi
-TOOL_PRODUCT_NAME="$(basename "${THIS_PLUGIN_DIR}")"
-readonly TOOL_PRODUCT_NAME
 
 PRODUCT_NAME=""
 PRODUCT_NAME="$(basename "$(dirname "${LIB_DIR}")")"
 readonly PRODUCT_NAME
+readonly TOOL_NAME="apache-${PRODUCT_NAME}"
 
-readonly TOOL_NAME="apache"
+PLUGIN_NAME="apache"
+readonly PLUGIN_NAME
 
 fail() {
-  echo -e "asdf-$TOOL_NAME|$TOOL_PRODUCT_NAME: $*"
+  echo -e "asdf-${PLUGIN_NAME}|$TOOL_NAME: $*"
   exit 1
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,11 +2,10 @@
 
 set -euo pipefail
 
-TOOL_PRODUCT_NAME=""
-TOOL_PRODUCT_NAME="$(basename "$(dirname ${ASDF_INSTALL_PATH})")"
+TOOL_PRODUCT_NAME="$(basename "$(dirname "${ASDF_INSTALL_PATH}")")"
 readonly TOOL_PRODUCT_NAME
 
-readonly TOOL_NAME="asdf-apache"
+readonly TOOL_NAME="apache"
 
 fail() {
   echo -e "asdf-$TOOL_NAME|$TOOL_PRODUCT_NAME: $*"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
 TOOL_PRODUCT_NAME="$(basename "$(dirname "${ASDF_INSTALL_PATH}")")"
 readonly TOOL_PRODUCT_NAME
 
@@ -123,7 +122,7 @@ default_filename_extended_pattern() {
   echo "\".*${product_name}-${version}.(${file_extensions})\""
 }
 
-grep_filename() {
+default_grep_filename() {
   local product_name="$1"
   local version_folder_url="$2"
   local raw_user_version_arg="$3"
@@ -141,12 +140,21 @@ get_download_url() {
   local product_name="$1"
   local semver="$2"
   local raw_user_version_arg="$3"
+  local -r product_file="${LIB_DIR}/${PRODUCT_NAME}.sh"
+  if [ -f "${product_file}" ]; then
+    # shellcheck disable=SC1090
+    . "${product_file}"
+  fi
   local dist_folder_url=""
   dist_folder_url="$(get_dist_folder "${product_name}")"
   local version_folder=""
   version_folder="$(get_version_folder "${product_name}" "${semver}")"
   [ -z "${version_folder}" ] && fail "Could not get subversion folder for '${semver}' in '${dist_folder_url}'"
   local filename=""
-  filename="$(grep_filename "${product_name}" "${dist_folder_url}/${version_folder}" "${raw_user_version_arg}")"
+  if [[ $(type -t grep_filename) == function ]]; then
+    filename="$(grep_filename "${product_name}" "${dist_folder_url}/${version_folder}" "${raw_user_version_arg}")"
+  else
+    filename="$(default_grep_filename "${product_name}" "${dist_folder_url}/${version_folder}" "${raw_user_version_arg}")"
+  fi
   echo "${dist_folder_url}/${version_folder}/${filename}"
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -172,7 +172,3 @@ get_download_url() {
   fi
   echo "${dist_folder_url}/${version_folder}/${filename}"
 }
-
-if [ -n "${DEBUG}" ]; then
-  set +x
-fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
-if [ -n "${DEBUG}" ]; then
+DEBUG="${DEBUG:-}"
+
+if [ -n "${DEBUG:-}" ]; then
   set -xv
 fi
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+if [ -n "${DEBUG}" ]; then
+  set -xv
+fi
+
 command -vp curl >/dev/null 2>&1 || fail 'Missing curl'
 command -v parallel >/dev/null 2>&1 || fail 'Missing gnu parallel'
 
@@ -166,3 +170,7 @@ get_download_url() {
   fi
   echo "${dist_folder_url}/${version_folder}/${filename}"
 }
+
+if [ -n "${DEBUG}" ]; then
+  set +x
+fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -5,7 +5,7 @@ set -euo pipefail
 DEBUG="${DEBUG:-}"
 
 if [ -n "${DEBUG:-}" ]; then
-  set -xv
+  set -x
 fi
 
 command -vp curl >/dev/null 2>&1 || fail 'Missing curl'

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-TOOL_PRODUCT_NAME="$(basename "$(dirname "${ASDF_INSTALL_PATH}")")"
+
+command -vp curl >/dev/null 2>&1 || fail 'Missing curl'
+command -v parallel >/dev/null 2>&1 || fail 'Missing gnu parallel'
+
+LIB_DIR=""
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly LIB_DIR
+
+if [ -z "${THIS_PLUGIN_DIR:-}" ]; then
+  THIS_PLUGIN_DIR="$(dirname "${LIB_DIR}")"
+fi
+TOOL_PRODUCT_NAME="$(basename "${THIS_PLUGIN_DIR}")"
 readonly TOOL_PRODUCT_NAME
+
+PRODUCT_NAME=""
+PRODUCT_NAME="$(basename "$(dirname "${LIB_DIR}")")"
+readonly PRODUCT_NAME
 
 readonly TOOL_NAME="apache"
 
@@ -12,13 +27,6 @@ fail() {
 }
 
 curl_opts=(-fsSL)
-
-LIB_DIR=""
-LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly LIB_DIR
-PRODUCT_NAME=""
-PRODUCT_NAME="$(basename "$(dirname "${LIB_DIR}")")"
-readonly PRODUCT_NAME
 
 install_version() {
   # shellcheck disable=SC2034

--- a/lib/zeppelin.sh
+++ b/lib/zeppelin.sh
@@ -13,9 +13,9 @@ list_sub_versions() {
   if [ "${include_src}" = "true" ]; then
     fail "Cannot currently handle source download"
   elif [ "${include_netinst}" = "true" ]; then
-    printf "%s\n" "${file_names}" | grep -E "(bin-all|bin-netinst).${FILE_EXT}" | sed "s/-bin-all.${FILE_EXT}//" | sed "s/-bin-netinst.${FILE_EXT}/-netinst/"
+    printf "%s\n" "${file_names}" | grep -E "(bin-all|bin-netinst).${FILE_EXT}" | sed "s/-bin-all.${FILE_EXT}//" | sed "s/-bin-netinst.${FILE_EXT}/-netinst/" | sed 's/zeppelin-//'
   else
-    printf "%s\n" "${file_names}" | grep -E "bin-all.${FILE_EXT}" | sed "s/-bin-all.${FILE_EXT}//"
+    printf "%s\n" "${file_names}" | grep -E "bin-all.${FILE_EXT}" | sed "s/-bin-all.${FILE_EXT}//" | sed 's/zeppelin-//'
   fi
 }
 

--- a/lib/zeppelin.sh
+++ b/lib/zeppelin.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FILE_EXT='tgz'
+
+list_sub_versions() {
+  local -r file_names="$1"
+  local -r include_src="${2:-false}"
+
+  local -r include_netinst="true"
+
+  if [ "${include_src}" = "true" ]; then
+    fail "Cannot currently handle source download"
+  elif [ "${include_netinst}" = "true" ]; then
+    printf "%s\n" "${file_names}" | grep -E "(bin-all|bin-netinst).${FILE_EXT}" | sed "s/-bin-all.${FILE_EXT}//" | sed "s/-bin-netinst.${FILE_EXT}/-netinst/"
+  else
+    printf "%s\n" "${file_names}" | grep -E "bin-all.${FILE_EXT}" | sed "s/-bin-all.${FILE_EXT}//"
+  fi
+}
+
+grep_filename() {
+  local product_name="$1"
+  # shellcheck disable=SC2034
+  local version_folder_url="$2"
+  local raw_user_version_arg="$3"
+
+  raw_user_version_arg_to_filename "${product_name}" "${raw_user_version_arg}"
+}
+
+raw_user_version_arg_to_filename() {
+  local -r product_name="$1"
+  local -r raw_user_version_arg="$2"
+  if printf '%s' "${raw_user_version_arg}" | grep -q '-netinst'; then
+    printf '%s.%s' "${product_name}-${raw_user_version_arg}" "${FILE_EXT}" | sed 's/netinst/bin-netinst/'
+  else
+    printf '%s' "${product_name}-${raw_user_version_arg}-bin-all.${FILE_EXT}"
+  fi
+}

--- a/scripts/fmt.bash
+++ b/scripts/fmt.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ -z "${BASH_SOURCE[0]:-}" ]; then
+  # zsh
+  SCRIPTS_DIR="${0:A:h}"
+else
+  SCRIPTS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+fi
+
+old_pwd="${PWD}"
+
+SCRIPTS_ROOT="$(dirname "${SCRIPTS_BIN_DIR}")"
+
+cd "${SCRIPTS_ROOT}" || exit 1
+for file in $(shfmt -f .); do
+  shfmt -w "${file}"
+done
+cd "${old_pwd}" || exit 1


### PR DESCRIPTION
+ blocker for openoffice as it's unsupported
+ product specific for zeppelin to make it easier to maintain
+ upgrades asdf plugin
+ latest-stable option
+ auto formatter
+ updates docs for zeppelin
+ switches to `true` and `false` for env vars instead of 1 and 0
~ centralizes more into utils 